### PR TITLE
Add user data script and configure EC2 security group rules

### DIFF
--- a/Terraform/install.sh
+++ b/Terraform/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+apt-get update -y
+apt-get upgrade -y
+apt-get install -y ca-certificates curl gnupg apt-transport-https software-properties-common default-jdk
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+usermod -aG docker ubuntu
+systemctl enable docker
+systemctl start docker

--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -13,7 +13,7 @@ resource "aws_instance" "ec2" {
   subnet_id              = aws_subnet.public-subnet[count.index].id
   instance_type          = var.ec2_instance_type[count.index]
   iam_instance_profile   = "EMR_EC2_DefaultRole"
-  key_name               = "devsecops-k8s-key"
+  key_name               = "LoginKey"
   user_data = file("${path.module}/install.sh")
   vpc_security_group_ids = [aws_security_group.default-ec2-sg.id]
   root_block_device {

--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -14,6 +14,7 @@ resource "aws_instance" "ec2" {
   instance_type          = var.ec2_instance_type[count.index]
   iam_instance_profile   = "EMR_EC2_DefaultRole"
   key_name               = "devsecops-k8s-key"
+  user_data = file("${path.module}/install.sh")
   vpc_security_group_ids = [aws_security_group.default-ec2-sg.id]
   root_block_device {
     volume_size = var.ec2_volume_size

--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -14,7 +14,7 @@ resource "aws_instance" "ec2" {
   instance_type          = var.ec2_instance_type[count.index]
   iam_instance_profile   = "EMR_EC2_DefaultRole"
   key_name               = "LoginKey"
-  user_data = file("${path.module}/install.sh")
+  user_data              = file("${path.module}/install.sh")
   vpc_security_group_ids = [aws_security_group.default-ec2-sg.id]
   root_block_device {
     volume_size = var.ec2_volume_size

--- a/Terraform/vpc.tf
+++ b/Terraform/vpc.tf
@@ -76,10 +76,35 @@ resource "aws_security_group" "default-ec2-sg" {
   vpc_id = aws_vpc.vpc.id
 
   ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"] // It should be specific IP range
+    description = "Allow SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow Jenkins"
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow SonarQube"
+    from_port   = 9000
+    to_port     = 9000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow Web Application"
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {


### PR DESCRIPTION
**Provisioning & Automation**
* Added `install.sh` to automate Docker/Docker Compose setup, user permissions, and service initialization on EC2.
* Updated `main.tf` to use `install.sh` via `user_data` and switched the SSH key to `LoginKey`. 

**Security Improvements**
* Hardened Security Groups by replacing "allow all" rules with specific ingress for SSH (22), Jenkins (8080), SonarQube (9000), and Web (3000).

---
**Linked Issues:** Closes #24, Closes #25